### PR TITLE
[개선] 기본 썸네일 반환

### DIFF
--- a/src/main/java/odyssey/backend/image/service/ImageService.java
+++ b/src/main/java/odyssey/backend/image/service/ImageService.java
@@ -12,7 +12,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.file.*;
-import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -28,7 +27,17 @@ public class ImageService {
     private final ImageRepository imageRepository;
 
     public Image save(MultipartFile file, Roadmap roadmap) {
-        if (!Objects.requireNonNull(file.getContentType()).startsWith("image/")) {
+        if(file == null || file.isEmpty()) {
+            return imageRepository.save(
+                    Image.builder()
+                            .url("/uploads/thumbnails/썸네일.jpg")
+                            .roadmap(roadmap)
+                            .build()
+            );
+        }
+
+        String contentType = file.getContentType();
+        if(contentType == null || !contentType.startsWith("image/")) {
             throw new InvalidImageFormatException();
         }
 


### PR DESCRIPTION
만일 로드맵을 만들 때 이미지가 들어오지않으면 기본 썸네일이 반환되도록 하였습니다.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #71 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 기본 썸네일이 반환되도록 하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 로드맵 생성 시, 이미지를 넣지 않더라도 기본 이미지url이 썸네일에 저장되도록 하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

