### PR TITLE
[개선] 로드맵은 무조건 디렉토리 안에

### DIFF
--- a/src/main/java/odyssey/backend/application/roadmap/RoadmapFacade.java
+++ b/src/main/java/odyssey/backend/application/roadmap/RoadmapFacade.java
@@ -31,11 +31,7 @@ public class RoadmapFacade {
     @Transactional
     public PersonalRoadmapResponse savePersonalRoadmap(RoadmapRequest request, MultipartFile thumbnail, User user){
 
-        Directory directory = null;
-
-        if (request.getDirectoryId() != null) {
-            directory = directoryService.findDirectoryById(request.getDirectoryId());
-        }
+        Directory directory = directoryService.findDirectoryById(request.getDirectoryId());
 
         String url = s3Service.uploadFile(thumbnail);
 
@@ -55,11 +51,7 @@ public class RoadmapFacade {
         String url = s3Service.uploadFile(thumbnail);
         Team team = teamService.findByTeamId(teamId);
 
-        Directory directory = null;
-
-        if (request.getDirectoryId() != null) {
-            directory = directoryService.findDirectoryById(request.getDirectoryId());
-        }
+        Directory directory = directoryService.findDirectoryById(request.getDirectoryId());
 
         return TeamRoadmapResponse.from(roadmapRepository.save(
                 Roadmap.from(request, url, directory, user, team)), user.getUuid());

--- a/src/main/java/odyssey/backend/application/root/RootUseCase.java
+++ b/src/main/java/odyssey/backend/application/root/RootUseCase.java
@@ -3,11 +3,9 @@ package odyssey.backend.application.root;
 import lombok.RequiredArgsConstructor;
 import odyssey.backend.domain.auth.User;
 import odyssey.backend.domain.directory.Directory;
-import odyssey.backend.domain.roadmap.Roadmap;
 import odyssey.backend.infrastructure.persistence.directory.DirectoryRepository;
 import odyssey.backend.infrastructure.persistence.roadmap.RoadmapRepository;
 import odyssey.backend.presentation.directory.dto.response.DirectoryResponse;
-import odyssey.backend.presentation.roadmap.dto.response.SimpleRoadmapResponse;
 import odyssey.backend.presentation.root.dto.response.RootContentResponse;
 import org.springframework.stereotype.Service;
 
@@ -22,32 +20,22 @@ public class RootUseCase {
 
     public RootContentResponse getRootContents(User user) {
         List<Directory> rootDirectories = directoryRepository.findByParentIsNullAndUser(user);
-        List<Roadmap> rootRoadmaps = roadmapRepository.findByDirectoryIsNullAndUser(user);
 
         List<DirectoryResponse> directoryResponses = rootDirectories.stream()
                 .map(DirectoryResponse::from)
                 .toList();
 
-        List<SimpleRoadmapResponse> roadmapResponses = rootRoadmaps.stream()
-                .map(SimpleRoadmapResponse::from)
-                .toList();
-
-        return RootContentResponse.from(directoryResponses, roadmapResponses);
+        return RootContentResponse.from(directoryResponses);
     }
 
     public RootContentResponse getTeamRootContents(User user, Long teamId) {
         List<Directory> rootDirectories = directoryRepository.findByParentIsNullAndTeamId(teamId);
-        List<Roadmap> rootRoadmaps = roadmapRepository.findByDirectoryIsNullAndTeamId(teamId);
 
         List<DirectoryResponse> directoryResponses = rootDirectories.stream()
                 .map(DirectoryResponse::from)
                 .toList();
 
-        List<SimpleRoadmapResponse> roadmapResponses = rootRoadmaps.stream()
-                .map(SimpleRoadmapResponse::from)
-                .toList();
-
-        return RootContentResponse.from(directoryResponses, roadmapResponses);
+        return RootContentResponse.from(directoryResponses);
     }
 
 }

--- a/src/main/java/odyssey/backend/domain/roadmap/Roadmap.java
+++ b/src/main/java/odyssey/backend/domain/roadmap/Roadmap.java
@@ -51,7 +51,7 @@ public class Roadmap {
     private List<Node> nodes;
 
     @ManyToOne
-    @JoinColumn(name = "directory_id")
+    @JoinColumn(name = "directory_id", nullable = false)
     private Directory directory;
 
     @ManyToOne

--- a/src/main/java/odyssey/backend/infrastructure/persistence/roadmap/RoadmapRepository.java
+++ b/src/main/java/odyssey/backend/infrastructure/persistence/roadmap/RoadmapRepository.java
@@ -1,7 +1,7 @@
 package odyssey.backend.infrastructure.persistence.roadmap;
 
-import odyssey.backend.domain.roadmap.Roadmap;
 import odyssey.backend.domain.auth.User;
+import odyssey.backend.domain.roadmap.Roadmap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,9 +9,7 @@ import java.util.Optional;
 
 public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
     Optional<Roadmap> findTopByUserOrderByLastAccessedAtDesc(User user);
-    List<Roadmap> findByDirectoryIsNullAndUser(User user);
     List<Roadmap> findByUserAndTeamIdIsNullOrderByLastAccessedAtDesc(User user);
     List<Roadmap> findByTeamIdOrderByLastAccessedAtDesc(Long teamId);
-    List<Roadmap> findByDirectoryIsNullAndTeamId(Long teamId);
     Long countByUser(User user);
 }

--- a/src/main/java/odyssey/backend/presentation/roadmap/dto/request/RoadmapRequest.java
+++ b/src/main/java/odyssey/backend/presentation/roadmap/dto/request/RoadmapRequest.java
@@ -2,6 +2,7 @@ package odyssey.backend.presentation.roadmap.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +24,7 @@ public class RoadmapRequest {
     @NotEmpty(message = "필수값입니다.")
     private List<String> categories;
 
+    @NotNull(message = "필수값입니다.")
     private Long directoryId;
 
 }

--- a/src/main/java/odyssey/backend/presentation/root/dto/response/RootContentResponse.java
+++ b/src/main/java/odyssey/backend/presentation/root/dto/response/RootContentResponse.java
@@ -1,15 +1,13 @@
 package odyssey.backend.presentation.root.dto.response;
 
 import odyssey.backend.presentation.directory.dto.response.DirectoryResponse;
-import odyssey.backend.presentation.roadmap.dto.response.SimpleRoadmapResponse;
 
 import java.util.List;
 
 public record RootContentResponse(
-        List<DirectoryResponse> directories,
-        List<SimpleRoadmapResponse> roadmaps
+        List<DirectoryResponse> directories
 ) {
-    public static RootContentResponse from(List<DirectoryResponse> directories, List<SimpleRoadmapResponse> roadmaps) {
-        return new RootContentResponse(directories, roadmaps);
+    public static RootContentResponse from(List<DirectoryResponse> directories) {
+        return new RootContentResponse(directories);
     }
 }

--- a/src/test/java/odyssey/backend/roadmap/TeamRoadmapControllerTest.java
+++ b/src/test/java/odyssey/backend/roadmap/TeamRoadmapControllerTest.java
@@ -88,7 +88,7 @@ public class TeamRoadmapControllerTest extends RestDocsSupport {
                 "팀 타이틀 생성",
                 "팀 설명 생성",
                 List.of("카테고리1", "카테고리2"),
-                null
+                1L
         );
 
         MockMultipartFile thumbnail = new MockMultipartFile(

--- a/src/test/java/odyssey/backend/root/RootControllerTest.java
+++ b/src/test/java/odyssey/backend/root/RootControllerTest.java
@@ -2,7 +2,6 @@ package odyssey.backend.root;
 
 import odyssey.backend.global.RestDocsSupport;
 import odyssey.backend.presentation.directory.dto.response.DirectoryResponse;
-import odyssey.backend.presentation.roadmap.dto.response.SimpleRoadmapResponse;
 import odyssey.backend.presentation.root.dto.response.RootContentResponse;
 import org.junit.jupiter.api.Test;
 
@@ -22,8 +21,7 @@ public class RootControllerTest extends RestDocsSupport {
     @Test
     void 루트_컨텐츠를_조회한다() throws Exception {
         DirectoryResponse directory = new DirectoryResponse(1L, "루트 디렉토리", null, List.of(), List.of());
-        SimpleRoadmapResponse roadmap = new SimpleRoadmapResponse(1L, "루트 로드맵");
-        RootContentResponse response = new RootContentResponse(List.of(directory), List.of(roadmap));
+        RootContentResponse response = new RootContentResponse(List.of(directory));
 
         given(rootUseCase.getRootContents(any()))
                 .willReturn(response);

--- a/src/test/java/odyssey/backend/root/RootControllerTest.java
+++ b/src/test/java/odyssey/backend/root/RootControllerTest.java
@@ -30,8 +30,6 @@ public class RootControllerTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.directories[0].id").value(1L))
                 .andExpect(jsonPath("$.data.directories[0].name").value("루트 디렉토리"))
-                .andExpect(jsonPath("$.data.roadmaps[0].id").value(1L))
-                .andExpect(jsonPath("$.data.roadmaps[0].title").value("루트 로드맵"))
                 .andDo(document("directory-root-contents",
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),
@@ -40,9 +38,7 @@ public class RootControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.directories[].name").description("디렉토리 이름"),
                                 fieldWithPath("data.directories[].parentId").description("상위 디렉토리 ID").optional(),
                                 fieldWithPath("data.directories[].directories").description("하위 디렉토리 리스트"),
-                                fieldWithPath("data.directories[].roadmaps").description("디렉토리에 포함된 로드맵 리스트"),
-                                fieldWithPath("data.roadmaps[].id").description("로드맵 ID"),
-                                fieldWithPath("data.roadmaps[].title").description("로드맵 제목")
+                                fieldWithPath("data.directories[].roadmaps").description("디렉토리에 포함된 로드맵 리스트")
                         )
                 ));
 


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #156 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 로드맵이 최상단에 생성되지 않도록 수정하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 로드맵 엔티티 테이블 Directory 컬럼에 nullable을 true로 수정
- 서비스 코드 내의 기본적으로 디렉토리를 null로 받던 코드 수정
- 테스트 코드 수정
- 최상단 컨텐츠 조회 수정


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

