### PR TITLE
[버그] CD에서 asciidocter 때문에 빌드가 안 되는 오류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ asciidoctor {
 
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
+    onlyIf { file(snippetsDir).exists() }
 
     sources {
         include('**/index.adoc', '**/docs/*.adoc')


### PR DESCRIPTION
snippetsDir이 있을 때만 돌도록 변경

## 🎫 관련 이슈

close #171 

<br>

## 📄 개요

> asciidocter가 Dir이 있을 때만 돌도록 변경

<br>

## 🔨 작업 내용


- asciidocter가 Dir이 있을 때만 돌도록 변경


<br>

## 🏁 확인 사항


- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

