### PR TITLE
[개선] 실시간 노드 이동 기능 분리

### DIFF
--- a/src/main/java/odyssey/backend/application/node/NodeService.java
+++ b/src/main/java/odyssey/backend/application/node/NodeService.java
@@ -1,7 +1,6 @@
 package odyssey.backend.application.node;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import odyssey.backend.domain.node.Node;
 import odyssey.backend.domain.node.exception.NodeNotFoundException;
 import odyssey.backend.domain.roadmap.Roadmap;
@@ -90,10 +89,6 @@ public class NodeService {
                 request.getCategory());
 
         NodeResponse response = NodeResponse.from(node);
-        
-        if (roadmap.getTeam() != null) {
-            messagingTemplate.convertAndSend("/topic/node/roadmap/" + roadmapId + "/updated", response);
-        }
 
         return response;
     }

--- a/src/main/java/odyssey/backend/presentation/websocket/WebSocketMessagingController.java
+++ b/src/main/java/odyssey/backend/presentation/websocket/WebSocketMessagingController.java
@@ -1,0 +1,44 @@
+package odyssey.backend.presentation.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import odyssey.backend.domain.auth.User;
+import odyssey.backend.presentation.node.dto.request.NodeRequest;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketMessagingController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/roadmap/{roadmapId}/nodes/{nodeId}")
+    public void broadcastNodeUpdate(
+            @DestinationVariable Long roadmapId,
+            @DestinationVariable Long nodeId,
+            @Payload NodeRequest nodeRequest,
+            Principal principal
+    ) {
+        User user = extractUser(principal);
+
+        log.debug("노드 실시간 메시징 - 로드맵ID: {}, 노드ID: {}, 사용자: {}", roadmapId, nodeId, user.getUsername());
+
+        messagingTemplate.convertAndSend(
+                "/topic/roadmap/" + roadmapId + "/nodes/" + nodeId,
+                nodeRequest
+        );
+    }
+
+    private User extractUser(Principal principal) {
+        UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) principal;
+        return (User) auth.getPrincipal();
+    }
+}

--- a/src/main/java/odyssey/backend/presentation/websocket/WebSocketSubscriptionController.java
+++ b/src/main/java/odyssey/backend/presentation/websocket/WebSocketSubscriptionController.java
@@ -7,7 +7,6 @@ import odyssey.backend.domain.auth.User;
 import odyssey.backend.infrastructure.websocket.WebSocketSessionManager;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
@@ -22,71 +21,7 @@ public class WebSocketSubscriptionController {
     private final WebSocketSessionManager sessionManager;
     private final TeamService teamService;
 
-    @SubscribeMapping("/topic/directory/team/{teamId}/created")
-    public void subscribeToTeamDirectoryCreated(@DestinationVariable Long teamId,
-                                                Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("디렉토리 생성 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
 
-    @SubscribeMapping("/topic/directory/team/{teamId}/updated")
-    public void subscribeToTeamDirectoryUpdated(@DestinationVariable Long teamId,
-                                                Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("디렉토리 업데이트 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
-
-    @SubscribeMapping("/topic/directory/team/{teamId}/deleted")
-    public void subscribeToTeamDirectoryDeleted(@DestinationVariable Long teamId,
-                                                Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("디렉토리 삭제 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
-
-    @SubscribeMapping("/topic/node/team/{teamId}/created")
-    public void subscribeToTeamNodeCreated(@DestinationVariable Long teamId,
-                                           Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("노드 생성 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
-
-    @SubscribeMapping("/topic/node/team/{teamId}/updated")
-    public void subscribeToTeamNodeUpdated(@DestinationVariable Long teamId,
-                                           Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("노드 업데이트 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
-
-    @SubscribeMapping("/topic/node/team/{teamId}/deleted")
-    public void subscribeToTeamNodeDeleted(@DestinationVariable Long teamId,
-                                           Principal principal) {
-        User user = extractUser(principal);
-        if (!teamService.isUserMemberOfTeam(user.getUuid(), teamId)) {
-            log.warn("노드 삭제 구독 권한 없음 - 사용자ID: {}, 팀ID: {}", user.getUuid(), teamId);
-            throw new AccessDeniedException("해당 팀의 멤버가 아닙니다: " + teamId);
-        }
-        sessionManager.subscribeToTeam(user.getUuid(), teamId);
-    }
 
     @MessageMapping("/subscribe/team/{teamId}")
     public void subscribeToTeam(@DestinationVariable Long teamId,


### PR DESCRIPTION
## 🎫 관련 이슈

close #216

<br>

## 📄 개요

> 노드 메세징과 저장 기능을 분리

<br>

## 🔨 작업 내용

- 메세징과 저장이 같이 되면 너무 과도한 디비 접근이 발생하여 수정


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
